### PR TITLE
docs(release): add 1.1.9 APK download

### DIFF
--- a/Android/README.md
+++ b/Android/README.md
@@ -10,11 +10,12 @@ It combines Bluetooth-based communication, offline map support, role-aware rescu
 - Cross-platform Android ↔ iOS Bluetooth voice calls over the GATT audio link (0xCD00), plus RFCOMM transport
 - End-to-end encrypted internet messaging over the Signal Protocol (libsignal, PQXDH), with 1:1 WebRTC voice and video calls
 - Crisis Sentinel: an on-device offline assistant (Google AI Edge LiteRT-LM) with an optional cloud engine
+- Secure Trust Dossiers for institutional-role documents, handwritten annotations, policy validation, and immutable manifests
 - Reliable image, voice, and file transfer with chunking, acknowledgements, and receipt tracking
 - SOS broadcasting and rescue-side discovery workflows
 - On-demand `feature_rescue` delivery for rescue operations
 - Offline map download, storage, and sharing powered by MapLibre
-- Built-in field tools such as compass, whistle, signal finder, and sensor-based utilities
+- Built-in field tools such as compass, whistle, signal finder, breadcrumb trail, CPR assist, flashlight patterns, and sensor-based utilities
 - Firebase Auth, Firestore, Functions, Crashlytics, Performance Monitoring, Analytics, and App Check integration
 - Android Keystore-backed identity material, encrypted local storage, and backend-issued role certificates
 
@@ -27,7 +28,7 @@ It combines Bluetooth-based communication, offline map support, role-aware rescu
 | `baselineprofile` | Baseline profile generator module for startup and scroll performance |
 | `functions` | Firebase Cloud Functions: role certificates, Play Integrity / App Attest verification, the encrypted messaging relay and prekey pool, VoIP push, SOS signal reporting, TURN credentials |
 | `dashboard` | Lightweight single-page summary surface for presenting the system at a high level |
-| `.github/workflows` | CI pipeline definitions for Android lint and unit-test validation |
+| `../.github/workflows` | Repository-level Android build and unit-test CI definitions |
 | `scripts` | Helper scripts such as Firebase config preparation |
 
 ## Core Product Areas
@@ -79,7 +80,7 @@ Firebase is used for identity, authorization-adjacent metadata, rescue telemetry
 Before building locally, make sure the following are available:
 
 - Android Studio with Android SDK 36
-- JDK 17 for Gradle / Android tooling compatibility
+- JDK 21 for Gradle and LiteRT-LM bytecode compatibility
 - Node.js 22 if you will build or deploy Firebase Functions
 - A Firebase project if you want live authentication, Firestore, App Check, or certificate issuance
 - Google Services configuration files for Android builds that use Firebase

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Thank you for your interest in contributing to Crisis Connect. This document pro
 
 ### Android
 
-**Requirements:** Android Studio Ladybug+, JDK 17, Android SDK 36
+**Requirements:** Android Studio Ladybug+, JDK 21, Android SDK 36
 
 ```bash
 git clone https://github.com/<your-username>/Crisis-Connect.git

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 <p align="center">
   <a href="https://play.google.com/store/apps/details?id=com.auralis.crisisconnect"><img src="https://img.shields.io/badge/Google%20Play-Download-3ddc84?style=for-the-badge&logo=google-play&logoColor=white" alt="Google Play" /></a>&nbsp;&nbsp;
   <a href="https://apps.apple.com/app/crisis-connect/id6759731195"><img src="https://img.shields.io/badge/App%20Store-Download-147efb?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store" /></a>&nbsp;&nbsp;
+  <a href="https://github.com/emirhan-duman/Crisis-Connect/releases/download/v1.1.9/crisis-connect-1.1.9-64.apk"><img src="https://img.shields.io/badge/Android%20APK-1.1.9-24292f?style=for-the-badge&logo=android&logoColor=white" alt="Download Android APK" /></a>&nbsp;&nbsp;
   <a href="https://crisisconnect.network"><img src="https://img.shields.io/badge/Website-crisisconnect.network-0f172a?style=for-the-badge&logo=safari&logoColor=white" alt="Website" /></a>
 </p>
 
@@ -522,12 +523,18 @@ outside this public mirror.
 
 ### Download the App
 
-The easiest way to use Crisis Connect is to download it from the app stores:
+The easiest way to use Crisis Connect is to download it from the app stores. Android users can
+also install the exact universal APK generated and signed by Google Play for release 1.1.9:
 
 <p align="center">
   <a href="https://play.google.com/store/apps/details?id=com.auralis.crisisconnect"><img src="https://img.shields.io/badge/Google%20Play-Download-3ddc84?style=for-the-badge&logo=google-play&logoColor=white" alt="Google Play" /></a>&nbsp;&nbsp;
-  <a href="https://apps.apple.com/app/crisis-connect/id6759731195"><img src="https://img.shields.io/badge/App%20Store-Download-147efb?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store" /></a>
+  <a href="https://apps.apple.com/app/crisis-connect/id6759731195"><img src="https://img.shields.io/badge/App%20Store-Download-147efb?style=for-the-badge&logo=app-store&logoColor=white" alt="App Store" /></a>&nbsp;&nbsp;
+  <a href="https://github.com/emirhan-duman/Crisis-Connect/releases/download/v1.1.9/crisis-connect-1.1.9-64.apk"><img src="https://img.shields.io/badge/Android%20APK-Direct%20download-24292f?style=for-the-badge&logo=android&logoColor=white" alt="Download Android APK" /></a>
 </p>
+
+The direct APK is `com.auralis.crisisconnect` version `1.1.9` (`versionCode` 64), supports
+Android 7.0+ and is signed with the Google Play app-signing certificate. Verify its SHA-256 before
+installing: `f690576ab7a1dd5d6266247a469bd5893bfbd082307d994982d918d69c3124e8`.
 
 ### Build From Source
 
@@ -535,7 +542,7 @@ The easiest way to use Crisis Connect is to download it from the app stores:
 
 | Platform | Requirements |
 |:--|:--|
-| **Android** | Android Studio Ladybug+ · JDK 17 · Android SDK 36 |
+| **Android** | Android Studio Ladybug+ · JDK 21 · Android SDK 36 |
 | **iOS** | Xcode 16+ · iOS 17+ deployment target · macOS Sequoia+ · Rust toolchain (to build the vendored native libraries) |
 | **Backend** | Node.js 20+ · Firebase CLI · Firebase project (Firestore, Auth, Functions) |
 
@@ -851,6 +858,7 @@ Crisis Connect is in production on both app stores and under active development.
 | **Website** | [crisisconnect.network](https://crisisconnect.network) |
 | **Website (TR)** | [crisisconnect.com.tr](https://crisisconnect.com.tr) |
 | **Google Play** | [Download for Android](https://play.google.com/store/apps/details?id=com.auralis.crisisconnect) |
+| **Android APK** | [Google Play-signed 1.1.9 universal APK](https://github.com/emirhan-duman/Crisis-Connect/releases/download/v1.1.9/crisis-connect-1.1.9-64.apk) |
 | **App Store** | [Download for iOS](https://apps.apple.com/app/crisis-connect/id6759731195) |
 
 </td>


### PR DESCRIPTION
## Summary

- add direct links to the Google Play-signed universal APK for Crisis Connect 1.1.9 (versionCode 64)
- document the verified package, minimum Android version, and SHA-256 digest
- update Android contributor prerequisites from JDK 17 to JDK 21 for LiteRT-LM compatibility
- refresh Android documentation for Trust Dossiers, new field tools, and the root CI workflow path

## Artifact verification

- package: `com.auralis.crisisconnect`
- version: `1.1.9` (`versionCode` 64)
- SHA-256: `f690576ab7a1dd5d6266247a469bd5893bfbd082307d994982d918d69c3124e8`
- Google Play signing certificate SHA-256: `bb3bf8e42bafd2094c1c66e51c7642c5152ffda472fa57b5733ca340dd5e13db`

The release asset will be published immediately after this documentation commit reaches `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Highlighted Secure Trust Dossiers and expanded field tools, including CPR assistance, flashlight patterns, and sensor utilities.
  * Added download information for the Google Play-signed Android APK version 1.1.9, including installation and SHA-256 verification guidance.
  * Updated Android development prerequisites from JDK 17 to JDK 21.
  * Corrected the documented workflow path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->